### PR TITLE
Sonar plugin is installed to Jenkins if SonarQube is available

### DIFF
--- a/containers/jenkins/resources/init.groovy.d/01-install-plugins.groovy
+++ b/containers/jenkins/resources/init.groovy.d/01-install-plugins.groovy
@@ -21,8 +21,6 @@ if (keyExists("dogu/sonar/current")) {
   plugins.add('sonar');
 }
 
-
-
 // action
 def jenkins = Jenkins.instance;
 def pluginManager = jenkins.pluginManager;


### PR DESCRIPTION
Solves #132 
Remember to build Jenkins manually for testing (--> remove 'jenkins' from setup.json).
