### PR TITLE
Redmine admin permissions

### DIFF
--- a/containers/redmine/Dockerfile
+++ b/containers/redmine/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --update redmine ruby-io-console build-base ruby-dev \
   && rm -rf /tmp/* /var/cache/apk/*
 
 ENV WORKDIR /usr/share/webapps/redmine
-ENV RMCASPLUGINVERSION 1.2.8
+ENV RMCASPLUGINVERSION 1.2.9
 ENV RUBYCASVERSION 2.3.13
 
 # Reinstall RMagick to make it work

--- a/containers/redmine/resources/workdir/app/models/auth_source_cas.rb.tpl
+++ b/containers/redmine/resources/workdir/app/models/auth_source_cas.rb.tpl
@@ -119,7 +119,10 @@ class AuthSourceCas < AuthSource
             end
             # remove user's admin rights if he is not in admin group any more
             if admingroup_exists
-              if not (user_groups.to_s.include?(ces_admin_group.gsub(\"\n\",\"\")))
+              if user_groups.to_s.include?(ces_admin_group.gsub(\"\n\",\"\"))
+                user.admin = 1
+                user.save
+              else
                 user.admin = 0
                 user.save
               end

--- a/containers/redmine/resources/workdir/app/models/auth_source_cas.rb.tpl
+++ b/containers/redmine/resources/workdir/app/models/auth_source_cas.rb.tpl
@@ -117,6 +117,13 @@ class AuthSourceCas < AuthSource
                 end
               end
             end
+            # remove user's admin rights if he is not in admin group any more
+            if admingroup_exists
+              if not (user_groups.to_s.include?(ces_admin_group.gsub(\"\n\",\"\")))
+                user.admin = 0
+                user.save
+              end
+            end
           end
           # return new user information
           retVal =

--- a/containers/redmine/startup.sh
+++ b/containers/redmine/startup.sh
@@ -52,6 +52,9 @@ else
   # Write base url to database
   mysql -h "${MYSQL_IP}" -u "${MYSQL_USER}" "-p${MYSQL_USER_PASSWORD}" -e "INSERT INTO ${MYSQL_DB}.settings VALUES (NULL,\"host_name\",\"https://$FQDN/redmine/\",4);"
 
+  # Remove default admin account
+  mysql -h "${MYSQL_IP}" -u "${MYSQL_USER}" "-p${MYSQL_USER_PASSWORD}" -e "DELETE FROM ${MYSQL_DB}.users WHERE login=\"admin\";"
+
   echo "Running plugins migrations..."
   su - redmine -c "rake redmine:plugins:migrate RAILS_ENV=$RAILS_ENV"
 fi


### PR DESCRIPTION
Redmine default admin account removed;
Redmine admin rights are granted/removed according to cas settings on login; works on browser and REST API access (sometimes only after second attempt)

For testing: Remember to build ecosystem without Redmine and build Redmine manually.

resolves https://github.com/cloudogu/ecosystem/issues/183
resolves https://github.com/cloudogu/ecosystem/issues/175
resolves https://github.com/cloudogu/ecosystem/issues/158