### PR TITLE
Updated JDK version

### DIFF
--- a/containers/jenkins/resources/init.groovy.d/init08javaautoinstall.groovy
+++ b/containers/jenkins/resources/init.groovy.d/init08javaautoinstall.groovy
@@ -6,7 +6,7 @@ import jenkins.model.Jenkins
 def descriptor = new JDK.DescriptorImpl();
 
 if (!descriptor.getInstallations()) {
-    def jdkInstaller = new JDKInstaller('jdk-8u102-oth-JPR', true)
-    def jdk = new JDK("jdk8u102", null, [new InstallSourceProperty([jdkInstaller])])
+    def jdkInstaller = new JDKInstaller('jdk-8u112-oth-JPR', true)
+    def jdk = new JDK("jdk8u112", null, [new InstallSourceProperty([jdkInstaller])])
     descriptor.setInstallations(jdk)
 }


### PR DESCRIPTION
Updated JDK version, because only most recent version can be automatically installed without an Oracle account.