### PR TITLE
removed base domain from mydestination because ces is not a mailserve…

### DIFF
--- a/containers/postfix/startup.sh
+++ b/containers/postfix/startup.sh
@@ -15,7 +15,7 @@ if [ ! -f /etc/postfix/configured ]; then
     done
     # POSTFIX CONFIG
     postconf -e myhostname="${name}.${domain}"
-    postconf -e mydestination="${name}.${domain}, ${domain}, localhost.localdomain, localhost"
+    postconf -e mydestination="${name}.${domain}, localhost.localdomain, localhost"
     postconf -e mynetworks="127.0.0.1 ${net}"
     postconf -e smtputf8_enable=no
     postconf -e relayhost=$MAILRELAY


### PR DESCRIPTION
…r for this domain. It just forwards mails to domain that my collide with the base domain if it was set in mydestination. E.g. if ces address is example.triology.de the base domain is triology.de, so ces was not able to forward mail to people@triology.de because of triology was set as mydestination. This commit removes that.