### PR TITLE
Feature/246 redmine plugin volume

### DIFF
--- a/containers/redmine/Dockerfile
+++ b/containers/redmine/Dockerfile
@@ -79,19 +79,6 @@ RUN git clone https://github.com/cloudogu/rubycas-client.git \
   && gem install rubycas-client-${RUBYCASVERSION}.gem \
   && rm -rf ../rubycas-client
 
-# Install Redmine CAS plugin
-USER ${USER}
-RUN curl -L -o casplugin${RMCASPLUGINVERSION}.tar.gz https://github.com/cloudogu/redmine_cas/archive/${RMCASPLUGINVERSION}.tar.gz \
-  && tar -xzf casplugin${RMCASPLUGINVERSION}.tar.gz \
-  && mv redmine_cas-${RMCASPLUGINVERSION} ${WORKDIR}/plugins/redmine_cas \
-  && rm casplugin${RMCASPLUGINVERSION}.tar.gz
-
-# Install redmine_activerecord_session_store plugin to make Single Sign-Out work
-RUN curl -L -o redmine_AR_session_store.tar.gz https://github.com/pencil/redmine_activerecord_session_store/archive/v0.0.1.tar.gz \
-  && tar -xzf redmine_AR_session_store.tar.gz \
-  && mv redmine_activerecord_session_store-0.0.1 ${WORKDIR}/plugins/redmine_activerecord_session_store \
-  && rm redmine_AR_session_store.tar.gz
-
 # redirect production.log to stdout to make it available in hosts /var/log/docker/redmine.log
 RUN ln -s /dev/stdout /usr/share/webapps/redmine/log/production.log
 

--- a/containers/redmine/dogu.json
+++ b/containers/redmine/dogu.json
@@ -1,6 +1,6 @@
 {
   "Name": "official/redmine",
-  "Version": "3.3.1-4",
+  "Version": "3.3.1-5",
   "DisplayName": "Redmine",
   "Description": "Redmine is a flexible project management web application",
   "Category": "Development Apps",

--- a/containers/redmine/dogu.json
+++ b/containers/redmine/dogu.json
@@ -18,7 +18,14 @@
     "Path": "/usr/share/webapps/redmine/files",
     "Owner": "1000",
     "Group": "1000"
-  }],
+    },
+    {
+    "Name": "plugins",
+    "Path": "/usr/share/webapps/redmine/plugins",
+    "Owner": "1000",
+    "Group": "1000"
+    }
+  ],
   "ServiceAccounts": [{
     "Type": "postgresql"
   }],
@@ -27,3 +34,4 @@
     "Port": 3000
   }
 }
+

--- a/containers/redmine/dogu.json
+++ b/containers/redmine/dogu.json
@@ -1,6 +1,6 @@
 {
   "Name": "official/redmine",
-  "Version": "3.3.1-3",
+  "Version": "3.3.1-4",
   "DisplayName": "Redmine",
   "Description": "Redmine is a flexible project management web application",
   "Category": "Development Apps",

--- a/containers/redmine/startup.sh
+++ b/containers/redmine/startup.sh
@@ -68,22 +68,27 @@ else
   # Remove default admin account
   sql "DELETE FROM users WHERE login='admin';"
 
-  # Install Redmine CAS plugin
-  echo "installing CAS plugin"
-  curl -L -o casplugin${RMCASPLUGINVERSION}.tar.gz https://github.com/cloudogu/redmine_cas/archive/${RMCASPLUGINVERSION}.tar.gz \
-    && tar -xzf casplugin${RMCASPLUGINVERSION}.tar.gz \
-    && mv redmine_cas-${RMCASPLUGINVERSION} ${WORKDIR}/plugins/redmine_cas \
-    && rm casplugin${RMCASPLUGINVERSION}.tar.gz
-  
+fi
+
+# Install base plugins for cloudogu
+if [ $(ls -l ${WORKDIR}/plugins/ | grep "redmine_activerecord" | wc -l) -eq 0 ]; then
   # Install redmine_activerecord_session_store plugin to make Single Sign-Out work
   echo "installing redmine_activerecord_session_store plugin"
   curl -L -o redmine_AR_session_store.tar.gz https://github.com/pencil/redmine_activerecord_session_store/archive/v0.0.1.tar.gz \
     && tar -xzf redmine_AR_session_store.tar.gz \
     && mv redmine_activerecord_session_store-0.0.1 ${WORKDIR}/plugins/redmine_activerecord_session_store \
     && rm redmine_AR_session_store.tar.gz
-
+fi
+if [ $(ls -l ${WORKDIR}/plugins/ | grep "redmine_cas" | wc -l) -eq 0 ]; then
+  # Install Redmine CAS plugin
+  echo "installing CAS plugin"
+  curl -L -o casplugin${RMCASPLUGINVERSION}.tar.gz https://github.com/cloudogu/redmine_cas/archive/${RMCASPLUGINVERSION}.tar.gz \
+    && tar -xzf casplugin${RMCASPLUGINVERSION}.tar.gz \
+    && mv redmine_cas-${RMCASPLUGINVERSION} ${WORKDIR}/plugins/redmine_cas \
+    && rm casplugin${RMCASPLUGINVERSION}.tar.gz
 fi
 
+# Install Plugins
 echo "running plugins migrations..."
   rake redmine:plugins:migrate RAILS_ENV=$RAILS_ENV -f ${WORKDIR}/Rakefile
 echo "plugins migrations... done"

--- a/containers/redmine/startup.sh
+++ b/containers/redmine/startup.sh
@@ -68,6 +68,20 @@ else
   # Remove default admin account
   sql "DELETE FROM users WHERE login='admin';"
 
+  # Install Redmine CAS plugin
+  echo "installing CAS plugin"
+  curl -L -o casplugin${RMCASPLUGINVERSION}.tar.gz https://github.com/cloudogu/redmine_cas/archive/${RMCASPLUGINVERSION}.tar.gz \
+    && tar -xzf casplugin${RMCASPLUGINVERSION}.tar.gz \
+    && mv redmine_cas-${RMCASPLUGINVERSION} ${WORKDIR}/plugins/redmine_cas \
+    && rm casplugin${RMCASPLUGINVERSION}.tar.gz
+  
+  # Install redmine_activerecord_session_store plugin to make Single Sign-Out work
+  echo "installing redmine_activerecord_session_store plugin"
+  curl -L -o redmine_AR_session_store.tar.gz https://github.com/pencil/redmine_activerecord_session_store/archive/v0.0.1.tar.gz \
+    && tar -xzf redmine_AR_session_store.tar.gz \
+    && mv redmine_activerecord_session_store-0.0.1 ${WORKDIR}/plugins/redmine_activerecord_session_store \
+    && rm redmine_AR_session_store.tar.gz
+
   echo "Running plugins migrations..."
   rake redmine:plugins:migrate RAILS_ENV=$RAILS_ENV -f ${WORKDIR}/Rakefile
 fi

--- a/containers/redmine/startup.sh
+++ b/containers/redmine/startup.sh
@@ -82,9 +82,12 @@ else
     && mv redmine_activerecord_session_store-0.0.1 ${WORKDIR}/plugins/redmine_activerecord_session_store \
     && rm redmine_AR_session_store.tar.gz
 
-  echo "Running plugins migrations..."
-  rake redmine:plugins:migrate RAILS_ENV=$RAILS_ENV -f ${WORKDIR}/Rakefile
 fi
+
+echo "running plugins migrations..."
+  rake redmine:plugins:migrate RAILS_ENV=$RAILS_ENV -f ${WORKDIR}/Rakefile
+echo "plugins migrations... done"
+
 
 # Create links
 if [ ! -e ${WORKDIR}/public/redmine ]; then


### PR DESCRIPTION
Please merge. I moved the installation of plugins to dogu startup in order to be able to install new plugins. Therefore i added a btrfs volume for the plugins. On startup this volume will be filled with the essential and neccessary plugins for cloudogu. Plugins that are found in addidtion will be installed right after that. Plugins that are already installed will be skipped by the redmine plugin migration automatically.

Tested with the plugins:
- cas
- crm
- helpdesk
- ass
- agile

