### PR TITLE
Feature/287 nexus proxy capability

### DIFF
--- a/containers/nexus/Dockerfile
+++ b/containers/nexus/Dockerfile
@@ -5,8 +5,9 @@ MAINTAINER Sebastian Sdorra <sebastian.sdorra@cloudogu.com>
 # dockerfile based on https://registry.hub.docker.com/u/sonatype/nexus/dockerfile/
 
 # The version of nexus to install
-ENV NEXUS_VERSION 2.14.3-02
-ENV CAS_PLUGIN_VERSION 1.2.2-SNAPSHOT
+ENV NEXUS_VERSION=2.14.3-02 \
+    CAS_PLUGIN_VERSION=1.2.2-SNAPSHOT \
+    SERVICE_TAGS=webapp
 
 RUN mkdir -p /opt/sonatype/nexus \
   && curl --fail --silent --location --retry 3 \
@@ -20,11 +21,12 @@ RUN mkdir -p /opt/sonatype/nexus \
 
 VOLUME /var/lib/nexus
 
-ENV SERVICE_TAGS webapp
-
 COPY resources /
 
 EXPOSE 8081
+
 USER nexus
+
 WORKDIR /opt/sonatype/nexus
-CMD /startup.sh
+
+CMD ["/startup.sh"]

--- a/containers/nexus/dogu.json
+++ b/containers/nexus/dogu.json
@@ -19,8 +19,13 @@
     "Owner": "1000",
     "Group": "1000"
   }],
-  "HealthCheck": {
-    "Type": "tcp",
-    "Port": 8081
-  }
+  "HealthChecks": [
+    {
+      "Type": "tcp",
+      "Port": 8081
+    },
+    {
+      "Type": "state"
+    }
+  ]
 }

--- a/containers/nexus/dogu.json
+++ b/containers/nexus/dogu.json
@@ -1,6 +1,6 @@
 {
   "Name": "official/nexus",
-  "Version": "2.14.3-2",
+  "Version": "2.14.3-3",
   "DisplayName": "Sonatype Nexus",
   "Description": "The Nexus Repository is like the local warehouse where all of the parts and finished goods used in your software supply chain are stored and distributed.",
   "Url": "http://www.sonatype.org/nexus",

--- a/containers/nexus/resources/startup.sh
+++ b/containers/nexus/resources/startup.sh
@@ -69,6 +69,7 @@ function startNexusAndWaitForHealth(){
   fi
 }
 
+doguctl state installing
 
 # create truststore
 TRUSTSTORE="/var/lib/nexus/truststore.jks"
@@ -115,4 +116,5 @@ echo "render_template"
 # update cas url
 render_template "/opt/sonatype/nexus/resources/cas-plugin.xml.tpl" > "/var/lib/nexus/conf/cas-plugin.xml"
 /configuration.sh "$ADMUSR" "$ADMPW" "$ADMINGROUP" &
+doguctl state ready
 exec $START_NEXUS

--- a/containers/nexus/resources/startup.sh
+++ b/containers/nexus/resources/startup.sh
@@ -43,6 +43,14 @@ function setProxyConfiguration(){
     else
       echo "Proxy server or port configuration missing in etcd."
     fi
+  else
+    PROXYSERVER=""
+    PROXYPORT=0
+    PROXYUSER=""
+    PROXYPASSWORD=""
+    writeProxyCredentialsTo "${NEXUS_CONFIGURATION}"
+    writeProxyAuthenticationCredentialsTo "${NEXUS_CONFIGURATION}"
+    putNexusConfiguration
   fi
 }
 

--- a/containers/nexus/resources/startup.sh
+++ b/containers/nexus/resources/startup.sh
@@ -3,8 +3,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-source /etc/ces/functions.sh
-
 # variables
 ADMUSR="admin"
 ADMDEFAULTPW="admin123"
@@ -17,6 +15,17 @@ function set_random_admin_password {
   curl -s --retry 3 --retry-delay 10 -X POST -H "Content-Type: application/json" -d "{data:{userId:\"$ADMUSR\",newPassword:\"$ADMPW\"}}" --insecure 'http://127.0.0.1:8081/nexus/service/local/users_setpw' -u "$ADMUSR":"$ADMDEFAULTPW"
   doguctl config -e "admin_password" "${ADMPW}"
   echo "${ADMPW}"
+}
+
+function render_template(){
+  FILE="$1"
+  if [ ! -f "$FILE" ]; then
+    echo >&2 "could not find template $FILE"
+    exit 1
+  fi
+
+  # render template
+  eval "echo \"$(cat $FILE)\""
 }
 
 function setProxyConfiguration(){

--- a/containers/nexus/spec/goss/goss.yaml
+++ b/containers/nexus/spec/goss/goss.yaml
@@ -1,0 +1,78 @@
+file:
+  /configuration.sh:
+    exists: true
+    mode: "0755"
+    size: 1205
+    owner: root
+    group: root
+    filetype: file
+    contains: []
+  /opt/sonatype/nexus:
+    exists: true
+    mode: "0755"
+    size: 104
+    owner: root
+    group: root
+    filetype: directory
+    contains: []
+  /startup.sh:
+    exists: true
+    mode: "0755"
+    size: 3199
+    owner: root
+    group: root
+    filetype: file
+    contains: []
+  /var/lib/nexus:
+    exists: true
+    mode: "0755"
+    size: 286
+    owner: nexus
+    group: nexus
+    filetype: directory
+    contains: []
+  /var/lib/nexus/conf/cas-plugin.xml:
+    exists: true
+    mode: "0644"
+    size: 371
+    owner: nexus
+    group: nexus
+    filetype: file
+    contains: []
+  /var/lib/nexus/plugin-repository/nexus-cas-plugin-1.2.2-SNAPSHOT:
+    exists: true
+    mode: "0755"
+    size: 110
+    owner: nexus
+    group: nexus
+    filetype: directory
+    contains: []
+  /var/lib/nexus/plugin-repository/nexus-cas-plugin-1.2.2-SNAPSHOT/META-INF:
+    exists: true
+    mode: "0755"
+    size: 22
+    owner: nexus
+    group: nexus
+    filetype: directory
+    contains: []
+  /var/lib/nexus/plugin-repository/nexus-cas-plugin-1.2.2-SNAPSHOT/dependencies:
+    exists: true
+    mode: "0755"
+    size: 328
+    owner: nexus
+    group: nexus
+    filetype: directory
+    contains: []
+user:
+  nexus:
+    exists: true
+    uid: 1000
+    gid: 1000
+    groups:
+    - nexus
+    home: /var/lib/nexus
+    shell: /bin/false
+group:
+  nexus:
+    exists: true
+    gid: 1000

--- a/containers/nexus/spec/goss/goss.yaml
+++ b/containers/nexus/spec/goss/goss.yaml
@@ -18,7 +18,6 @@ file:
   /startup.sh:
     exists: true
     mode: "0755"
-    size: 3199
     owner: root
     group: root
     filetype: file
@@ -26,7 +25,6 @@ file:
   /var/lib/nexus:
     exists: true
     mode: "0755"
-    size: 286
     owner: nexus
     group: nexus
     filetype: directory

--- a/containers/nexus/spec/goss/goss.yaml
+++ b/containers/nexus/spec/goss/goss.yaml
@@ -32,7 +32,6 @@ file:
   /var/lib/nexus/conf/cas-plugin.xml:
     exists: true
     mode: "0644"
-    size: 371
     owner: nexus
     group: nexus
     filetype: file


### PR DESCRIPTION
Resolves #287 
You need a proxy server for testing and the following commands to manually set the keys in etcd:
etcdctl set /config/_global/proxy/enabled true
etcdctl set /config/_global/proxy/server
etcdctl set /config/_global/proxy/port
etcdctl set /config/_global/proxy/username
etcdctl set /config/_global/proxy/password
Don't forget to simulate an offline environment (e.g. `route del default` on host)
For an easy way to set up a local squid proxy ask me.