### PR TITLE
Feature/postfix smtp security level

### DIFF
--- a/containers/postfix/resources/startup.sh
+++ b/containers/postfix/resources/startup.sh
@@ -24,8 +24,8 @@ postconf -e smtputf8_enable=no
 postconf -e relayhost="${MAILRELAY}"
 postconf -e smtpd_recipient_restrictions="permit_mynetworks,permit_sasl_authenticated,reject_unauth_destination"
 if [ $(doguctl config smtp_tls_security_level) ]; then
-  encrypt=$(doguctl config smtp_tls_security_level)
-  postconf -e smtp_tls_security_level="${encrypt}"
+  smtp_tls_security_level=$(doguctl config smtp_tls_security_level)
+  postconf -e smtp_tls_security_level="${smtp_tls_security_level}"
 fi
 
 # START POSTFIX

--- a/containers/postfix/resources/startup.sh
+++ b/containers/postfix/resources/startup.sh
@@ -23,6 +23,10 @@ postconf -e mynetworks="127.0.0.1 ${NET}"
 postconf -e smtputf8_enable=no
 postconf -e relayhost="${MAILRELAY}"
 postconf -e smtpd_recipient_restrictions="permit_mynetworks,permit_sasl_authenticated,reject_unauth_destination"
+if [ $(doguctl config smtp_tls_security_level) ]; then
+  encrypt=$(doguctl config smtp_tls_security_level)
+  postconf -e smtp_tls_security_level="${encrypt}"
+fi
 
 # START POSTFIX
 exec /usr/bin/supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
smtp_tls_security_level is set in postfix if a corresponding key has been created in the registry before.