### PR TITLE
#381 updated documentation of setup.json

### DIFF
--- a/docs/docs/user-guide/setup-json.md
+++ b/docs/docs/user-guide/setup-json.md
@@ -379,11 +379,17 @@ The following objects are examples:
       "retention_strategy": "removeAllButKeepLatest",
       "metrics_token": "metrics_123",
       "rest_token": "rest_123",
-      "admin_role": "backupAdmins"
+      "admin_role": "backupAdmins",
+      "deny_cross_blueprint_restores" : "false"
     }
   }
 }
 ```
+
+- Key: `"deny_cross_blueprint_restores"`
+  
+  When set to `true`, backups are bound to a blueprintId. After a blueprint-Upgrade the backups cannot be restored.
+  When not set or set to `false`, any backup can be restored.
 
 ##### cas
 

--- a/docs/docs/user-guide/setup-json_de.md
+++ b/docs/docs/user-guide/setup-json_de.md
@@ -384,11 +384,18 @@ Enthält beispielsweise folgende Objekte:
       "retention_strategy": "removeAllButKeepLatest",
       "metrics_token": "metrics_123",
       "rest_token": "rest_123",
-      "admin_role": "backupAdmins"
+      "admin_role": "backupAdmins",
+      "deny_cross_blueprint_restores" : "false"
     }
   }
 }
 ```
+
+- Key: `"deny_cross_blueprint_restores"`
+  
+  Wenn der Wert auf `true` gesetzt ist, sind die Backups an eine blueprintId gebunden. 
+  Nach einem Blueprint-Upgrade können sie nicht wiederhergestellt werden.
+  Wenn der Wert auf `false` oder gar nicht gesetzt ist, können alle Backups wiederhergestellt werden.
 
 ##### cas
 


### PR DESCRIPTION
Updated documentation of setup.json to contain the configuration to deny cross blueprint restores.

#Resolves 381