### PR TITLE
#366 Document setup.json properties for Split DNS configuration

### DIFF
--- a/docs/docs/user-guide/setup-json.md
+++ b/docs/docs/user-guide/setup-json.md
@@ -107,6 +107,18 @@ Properties:
 * Content: The mail address used by all dogus to send mails (the 'From:'-Field)
 * Example: `"mail@mydomain.com"`
 
+#### useInternalIp
+* Optional
+* Data type: boolean
+* Content: This switch enables the usage of a specific IP address for internal DNS resolution of the host. A value of `true` mandates a valid value in the field `internalIp`. If this field is not set it will be interpreted as `false` and ignored. 
+* Example: `"useInternalIp": true`
+
+#### internalIp
+* Optional 
+* Data type: String
+* Content: This field contains the IP address that should be used for internal DNS resolution of the host. This of special interest for installations that use a Split DNS configuration. In a Split DNS configuration the CES instance is available under a different IP address than from inside the CES. This field will be only evaluated if `userInternalIp` is set to `true`, otherwise it will be ignored.  
+* Example: `"internalIp": "10.0.2.15"`
+
 #### completed
 * Data type: boolean
 * Content: Logical value which shows if the *naming step* is completely finished

--- a/docs/docs/user-guide/setup-json.md
+++ b/docs/docs/user-guide/setup-json.md
@@ -116,7 +116,7 @@ Properties:
 #### internalIp
 * Optional 
 * Data type: String
-* Content: This field contains the IP address that should be used for internal DNS resolution of the host. This of special interest for installations that use a Split DNS configuration. In a Split DNS configuration the CES instance is available under a different IP address than from inside the CES. This field will be only evaluated if `userInternalIp` is set to `true`, otherwise it will be ignored.  
+* Content: This field contains the IP address that should be used for internal DNS resolution of the host. This is of special interest for installations that use a Split DNS configuration. In a Split DNS configuration the CES instance has a public IP address that is only reachable from the outside. Inside the CES instance a different, private IP address is used to interact with the internal parts of the instance. This field will be only evaluated if `userInternalIp` is set to `true`, otherwise it will be ignored.  
 * Example: `"internalIp": "10.0.2.15"`
 
 #### completed

--- a/docs/docs/user-guide/setup-json_de.md
+++ b/docs/docs/user-guide/setup-json_de.md
@@ -113,6 +113,18 @@ Eigenschaften:
 * Inhalt: Die Mail-Adresse, welche von allen Dogus verwendet wird, um Mails zu versenden (das 'From:'-Feld)
 * Beispiel: `"mail@mydomain.com"`
 
+#### useInternalIp
+* Optional
+* Datentyp: boolean
+* Inhalt: Dieser Schalter gibt an, ob eine spezifische IP-Adresse für eine interne DNS-Auflösung des Hosts verwendet werden soll. Wenn dieser Schalter auf `true` gesetzt wird, dann erzwingt dies, einen gültigen Wert im Feld `internalIp`. Wenn dieses Feld nicht gesetzt wurde, dann wird es mit `false` interpretiert und ignoriert. 
+* Beispiel: `"useInternalIp": true`
+
+#### internalIp
+* Optional 
+* Datentyp: String
+* Inhalt: Wenn und nur wenn `userInternalIp` wahr ist, wird die hier hinterlegte IP-Adresse für eine interne DNS-Auflösung des Hosts verwendet. Ansonsten wird dieses Feld ignoriert. Dies ist besonders für Installationen mit einer Split-DNS-Konfiguration interessant, d. h. wenn die Instanz von außen mit einer anderen IP-Adresse erreichbar ist, als von innen. 
+* Beispiel: `"internalIp": "10.0.2.15"`
+
 #### completed
 * Datentyp: boolean
 * Inhalt: Wahrheitswert, ob der Naming-Schritt komplett ist


### PR DESCRIPTION
This PR documents the `setup.json` fields both in english and german.