### PR TITLE
Create additional partitions

### DIFF
--- a/images/http/dev/user-data
+++ b/images/http/dev/user-data
@@ -67,10 +67,40 @@ autoinstall:
         number: 3
         size: 8G
         flag: swap
-      - id: sda4-root
+      - id: sda4-home
         device: sda
         type: partition
         number: 4
+        size: 2GB
+      - id: sda5-tmp
+        device: sda
+        type: partition
+        number: 5
+        size: 8GB
+      - id: sda6-var
+        device: sda
+        type: partition
+        number: 6
+        size: 40GB
+      - id: sda7-vartmp
+        device: sda
+        type: partition
+        number: 7
+        size: 8GB
+      - id: sda8-varlog
+        device: sda
+        type: partition
+        number: 8
+        size: 10GB
+      - id: sda9-varlogaudit
+        device: sda
+        type: partition
+        number: 9
+        size: 8GB
+      - id: sda10-root
+        device: sda
+        type: partition
+        number: 10
         size: -1
 
       - id: sda2-boot-ext4
@@ -81,15 +111,36 @@ autoinstall:
         type: format
         volume: sda3-swap
         fstype: swap
-      - id: sda4-root-btrfs
+      - id: sda4-home-ext4
         type: format
-        volume: sda4-root
+        volume: sda4-home
+        fstype: ext4
+      - id: sda5-tmp-ext4
+        type: format
+        volume: sda5-tmp
+        fstype: ext4
+      - id: sda6-var-btrfs
+        type: format
+        volume: sda6-var
         fstype: btrfs
+      - id: sda7-vartmp-ext4
+        type: format
+        volume: sda7-vartmp
+        fstype: ext4
+      - id: sda8-varlog-ext4
+        type: format
+        volume: sda8-varlog
+        fstype: ext4
+      - id: sda9-varlogaudit-ext4
+        type: format
+        volume: sda9-varlogaudit
+        fstype: ext4
+      - id: sda10-root-ext4
+        type: format
+        volume: sda10-root
+        fstype: ext4
 
-      - id: mount-sda4-root
-        type: mount
-        path: /
-        device: sda4-root-btrfs
+
       - id: mount-sda2-boot
         type: mount
         path: /boot
@@ -98,3 +149,31 @@ autoinstall:
         type: mount
         path: /swap.img
         device: sda3-swap-swap
+      - id: mount-sda4-home
+        type: mount
+        path: /home
+        device: sda4-home-ext4
+      - id: mount-sda5-tmp
+        type: mount
+        path: /tmp
+        device: sda5-tmp-ext4
+      - id: mount-sda6-var
+        type: mount
+        path: /var
+        device: sda6-var-btrfs
+      - id: mount-sda7-vartmp
+        type: mount
+        path: /var/tmp
+        device: sda7-vartmp-ext4
+      - id: mount-sda8-varlog
+        type: mount
+        path: /var/log
+        device: sda8-varlog-ext4
+      - id: mount-sda9-varlogaudit
+        type: mount
+        path: /var/log/audit
+        device: sda9-varlogaudit-ext4
+      - id: mount-sda10-root
+        type: mount
+        path: /
+        device: sda10-root-ext4

--- a/images/http/dev/user-data
+++ b/images/http/dev/user-data
@@ -77,27 +77,27 @@ autoinstall:
         type: partition
         number: 5
         size: 8GB
-      - id: sda6-var
+      - id: sda6-vartmp
         device: sda
         type: partition
         number: 6
-        size: 40GB
-      - id: sda7-vartmp
+        size: 8GB
+      - id: sda7-varlog
         device: sda
         type: partition
         number: 7
-        size: 8GB
-      - id: sda8-varlog
+        size: 10GB
+      - id: sda8-varlogaudit
         device: sda
         type: partition
         number: 8
-        size: 10GB
-      - id: sda9-varlogaudit
+        size: 8GB
+      - id: sda9-root
         device: sda
         type: partition
         number: 9
-        size: 8GB
-      - id: sda10-root
+        size: 10GB
+      - id: sda10-var
         device: sda
         type: partition
         number: 10
@@ -119,26 +119,26 @@ autoinstall:
         type: format
         volume: sda5-tmp
         fstype: ext4
-      - id: sda6-var-btrfs
+      - id: sda6-vartmp-ext4
         type: format
-        volume: sda6-var
+        volume: sda6-vartmp
+        fstype: ext4
+      - id: sda7-varlog-ext4
+        type: format
+        volume: sda7-varlog
+        fstype: ext4
+      - id: sda8-varlogaudit-ext4
+        type: format
+        volume: sda8-varlogaudit
+        fstype: ext4
+      - id: sda9-root-ext4
+        type: format
+        volume: sda9-root
+        fstype: ext4
+      - id: sda10-var-btrfs
+        type: format
+        volume: sda10-var
         fstype: btrfs
-      - id: sda7-vartmp-ext4
-        type: format
-        volume: sda7-vartmp
-        fstype: ext4
-      - id: sda8-varlog-ext4
-        type: format
-        volume: sda8-varlog
-        fstype: ext4
-      - id: sda9-varlogaudit-ext4
-        type: format
-        volume: sda9-varlogaudit
-        fstype: ext4
-      - id: sda10-root-ext4
-        type: format
-        volume: sda10-root
-        fstype: ext4
 
 
       - id: mount-sda2-boot
@@ -157,23 +157,23 @@ autoinstall:
         type: mount
         path: /tmp
         device: sda5-tmp-ext4
-      - id: mount-sda6-var
-        type: mount
-        path: /var
-        device: sda6-var-btrfs
-      - id: mount-sda7-vartmp
+      - id: mount-sda6-vartmp
         type: mount
         path: /var/tmp
-        device: sda7-vartmp-ext4
-      - id: mount-sda8-varlog
+        device: sda6-vartmp-ext4
+      - id: mount-sda7-varlog
         type: mount
         path: /var/log
-        device: sda8-varlog-ext4
-      - id: mount-sda9-varlogaudit
+        device: sda7-varlog-ext4
+      - id: mount-sda8-varlogaudit
         type: mount
         path: /var/log/audit
-        device: sda9-varlogaudit-ext4
-      - id: mount-sda10-root
+        device: sda8-varlogaudit-ext4
+      - id: mount-sda9-root
         type: mount
         path: /
-        device: sda10-root-ext4
+        device: sda9-root-ext4
+      - id: mount-sda10-var
+        type: mount
+        path: /var
+        device: sda10-var-btrfs

--- a/images/http/prod/QEMU/user-data
+++ b/images/http/prod/QEMU/user-data
@@ -77,27 +77,27 @@ autoinstall:
         type: partition
         number: 5
         size: 8GB
-      - id: vda6-var
+      - id: vda6-vartmp
         device: vda
         type: partition
         number: 6
-        size: 40GB
-      - id: vda7-vartmp
+        size: 8GB
+      - id: vda7-varlog
         device: vda
         type: partition
         number: 7
-        size: 8GB
-      - id: vda8-varlog
+        size: 10GB
+      - id: vda8-varlogaudit
         device: vda
         type: partition
         number: 8
-        size: 10GB
-      - id: vda9-varlogaudit
+        size: 8GB
+      - id: vda9-root
         device: vda
         type: partition
         number: 9
-        size: 8GB
-      - id: vda10-root
+        size: 10GB
+      - id: vda10-var
         device: vda
         type: partition
         number: 10
@@ -119,26 +119,27 @@ autoinstall:
         type: format
         volume: vda5-tmp
         fstype: ext4
-      - id: vda6-var-btrfs
+      - id: vda6-vartmp-ext4
         type: format
-        volume: vda6-var
+        volume: vda6-vartmp
+        fstype: ext4
+      - id: vda7-varlog-ext4
+        type: format
+        volume: vda7-varlog
+        fstype: ext4
+      - id: vda8-varlogaudit-ext4
+        type: format
+        volume: vda8-varlogaudit
+        fstype: ext4
+      - id: vda9-root-ext4
+        type: format
+        volume: vda9-root
+        fstype: ext4
+      - id: vda10-var-btrfs
+        type: format
+        volume: vda10-var
         fstype: btrfs
-      - id: vda7-vartmp-ext4
-        type: format
-        volume: vda7-vartmp
-        fstype: ext4
-      - id: vda8-varlog-ext4
-        type: format
-        volume: vda8-varlog
-        fstype: ext4
-      - id: vda9-varlogaudit-ext4
-        type: format
-        volume: vda9-varlogaudit
-        fstype: ext4
-      - id: vda10-root-ext4
-        type: format
-        volume: vda10-root
-        fstype: ext4
+
 
       - id: mount-vda2-boot
         type: mount
@@ -156,26 +157,26 @@ autoinstall:
         type: mount
         path: /tmp
         device: vda5-tmp-ext4
-      - id: mount-vda6-var
-        type: mount
-        path: /var
-        device: vda6-var-btrfs
-      - id: mount-vda7-vartmp
+      - id: mount-vda6-vartmp
         type: mount
         path: /var/tmp
-        device: vda7-vartmp-ext4
-      - id: mount-vda8-varlog
+        device: vda6-vartmp-ext4
+      - id: mount-vda7-varlog
         type: mount
         path: /var/log
-        device: vda8-varlog-ext4
-      - id: mount-vda9-varlogaudit
+        device: vda7-varlog-ext4
+      - id: mount-vda8-varlogaudit
         type: mount
         path: /var/log/audit
-        device: vda9-varlogaudit-ext4
-      - id: mount-vda10-root
+        device: vda8-varlogaudit-ext4
+      - id: mount-vda9-root
         type: mount
         path: /
-        device: vda10-root-ext4
+        device: vda9-root-ext4
+      - id: mount-vda10-var
+        type: mount
+        path: /var
+        device: vda10-var-btrfs
   network:
     network:
       version: 2

--- a/images/http/prod/QEMU/user-data
+++ b/images/http/prod/QEMU/user-data
@@ -67,10 +67,40 @@ autoinstall:
         number: 3
         size: 8G
         flag: swap
-      - id: vda4-root
+      - id: vda4-home
         device: vda
         type: partition
         number: 4
+        size: 2GB
+      - id: vda5-tmp
+        device: vda
+        type: partition
+        number: 5
+        size: 8GB
+      - id: vda6-var
+        device: vda
+        type: partition
+        number: 6
+        size: 40GB
+      - id: vda7-vartmp
+        device: vda
+        type: partition
+        number: 7
+        size: 8GB
+      - id: vda8-varlog
+        device: vda
+        type: partition
+        number: 8
+        size: 10GB
+      - id: vda9-varlogaudit
+        device: vda
+        type: partition
+        number: 9
+        size: 8GB
+      - id: vda10-root
+        device: vda
+        type: partition
+        number: 10
         size: -1
 
       - id: vda2-boot-ext4
@@ -81,15 +111,35 @@ autoinstall:
         type: format
         volume: vda3-swap
         fstype: swap
-      - id: vda4-root-btrfs
+      - id: vda4-home-ext4
         type: format
-        volume: vda4-root
+        volume: vda4-home
+        fstype: ext4
+      - id: vda5-tmp-ext4
+        type: format
+        volume: vda5-tmp
+        fstype: ext4
+      - id: vda6-var-btrfs
+        type: format
+        volume: vda6-var
         fstype: btrfs
+      - id: vda7-vartmp-ext4
+        type: format
+        volume: vda7-vartmp
+        fstype: ext4
+      - id: vda8-varlog-ext4
+        type: format
+        volume: vda8-varlog
+        fstype: ext4
+      - id: vda9-varlogaudit-ext4
+        type: format
+        volume: vda9-varlogaudit
+        fstype: ext4
+      - id: vda10-root-ext4
+        type: format
+        volume: vda10-root
+        fstype: ext4
 
-      - id: mount-vda4-root
-        type: mount
-        path: /
-        device: vda4-root-btrfs
       - id: mount-vda2-boot
         type: mount
         path: /boot
@@ -98,6 +148,34 @@ autoinstall:
         type: mount
         path: /swap.img
         device: vda3-swap-swap
+      - id: mount-vda4-home
+        type: mount
+        path: /home
+        device: vda4-home-ext4
+      - id: mount-vda5-tmp
+        type: mount
+        path: /tmp
+        device: vda5-tmp-ext4
+      - id: mount-vda6-var
+        type: mount
+        path: /var
+        device: vda6-var-btrfs
+      - id: mount-vda7-vartmp
+        type: mount
+        path: /var/tmp
+        device: vda7-vartmp-ext4
+      - id: mount-vda8-varlog
+        type: mount
+        path: /var/log
+        device: vda8-varlog-ext4
+      - id: mount-vda9-varlogaudit
+        type: mount
+        path: /var/log/audit
+        device: vda9-varlogaudit-ext4
+      - id: mount-vda10-root
+        type: mount
+        path: /
+        device: vda10-root-ext4
   network:
     network:
       version: 2

--- a/images/http/prod/no_varlog_partitions/meta-data
+++ b/images/http/prod/no_varlog_partitions/meta-data
@@ -1,0 +1,4 @@
+# This file needs to be present for Ubuntu 20.04 installer
+# Hint: This "no_varlog_partitions" folder holds configuration
+#   for images which should not get separate /var/log and
+#   /var/log/audit partitions.

--- a/images/http/prod/no_varlog_partitions/user-data
+++ b/images/http/prod/no_varlog_partitions/user-data
@@ -1,0 +1,156 @@
+#cloud-config
+autoinstall:
+  # Version of the autoinstall-specification
+  version: 1
+
+  # Settings for the apt repositories
+  apt:
+    geoip: true
+    preserve_sources_list: false
+    primary:
+      - arches: [ amd64, i386 ]
+        uri: http://de.archive.ubuntu.com/ubuntu
+      - arches: [ default ]
+        uri: http://ports.ubuntu.com/ubuntu-ports
+
+  # Settings for the user and groups
+  # The password is "ces-admin"
+  identity:
+    hostname: ces
+    password: $6$eXtrTEXrpV8WK64H$pvrncLTd2VyZ8sOk8hHc1PGl1ACmtv9Bu7Fsv69m0hu8ELYNipZcjwd9dfZzwMdlYuUYgiiA/rXYK.2v6Wi.X0
+    realname: ces-admin
+    username: ces-admin
+
+  # Contains the settings for the keyboard
+  keyboard:
+    layout: us
+    toggle: null
+    variant: ''
+
+  # The target locale
+  locale: en_US
+
+  # Contains settings for the ssh server
+  ssh:
+    allow-pw: true
+    authorized-keys: [ ]
+    install-server: true
+
+  # Contains the definition of the systems partitions
+  # Hint: This "no_varlog_partitions" folder holds configuration
+  #   for images which should NOT get separate /var/log and
+  #   /var/log/audit partitions.
+  storage:
+    version: 1
+    swap:
+      size: 0
+    config:
+      - id: sda
+        type: disk
+        ptable: gpt
+        path: /dev/sda
+        wipe: superblock
+        grub_device: true
+
+      - id: sda1-bios
+        device: sda
+        type: partition
+        number: 1
+        size: 1MB
+        flag: bios_grub
+      - id: sda2-boot
+        device: sda
+        type: partition
+        number: 2
+        size: 1GB
+        flag: boot
+      - id: sda3-swap
+        device: sda
+        type: partition
+        number: 3
+        size: 8G
+        flag: swap
+      - id: sda4-home
+        device: sda
+        type: partition
+        number: 4
+        size: 2GB
+      - id: sda5-tmp
+        device: sda
+        type: partition
+        number: 5
+        size: 8GB
+      - id: sda6-vartmp
+        device: sda
+        type: partition
+        number: 6
+        size: 8GB
+      - id: sda7-root
+        device: sda
+        type: partition
+        number: 7
+        size: 10GB
+      - id: sda8-var
+        device: sda
+        type: partition
+        number: 8
+        size: -1
+
+      - id: sda2-boot-ext4
+        type: format
+        volume: sda2-boot
+        fstype: ext4
+      - id: sda3-swap-swap
+        type: format
+        volume: sda3-swap
+        fstype: swap
+      - id: sda4-home-ext4
+        type: format
+        volume: sda4-home
+        fstype: ext4
+      - id: sda5-tmp-ext4
+        type: format
+        volume: sda5-tmp
+        fstype: ext4
+      - id: sda6-vartmp-ext4
+        type: format
+        volume: sda6-vartmp
+        fstype: ext4
+      - id: sda7-root-ext4
+        type: format
+        volume: sda7-root
+        fstype: ext4
+      - id: sda8-var-btrfs
+        type: format
+        volume: sda8-var
+        fstype: btrfs
+
+
+      - id: mount-sda2-boot
+        type: mount
+        path: /boot
+        device: sda2-boot-ext4
+      - id: mount-sda3-swap
+        type: mount
+        path: /swap.img
+        device: sda3-swap-swap
+      - id: mount-sda4-home
+        type: mount
+        path: /home
+        device: sda4-home-ext4
+      - id: mount-sda5-tmp
+        type: mount
+        path: /tmp
+        device: sda5-tmp-ext4
+      - id: mount-sda6-vartmp
+        type: mount
+        path: /var/tmp
+        device: sda6-vartmp-ext4
+      - id: mount-sda7-root
+        type: mount
+        path: /
+        device: sda7-root-ext4
+      - id: mount-sda8-var
+        type: mount
+        path: /var
+        device: sda8-var-btrfs

--- a/images/http/prod/user-data
+++ b/images/http/prod/user-data
@@ -67,10 +67,40 @@ autoinstall:
         number: 3
         size: 8G
         flag: swap
-      - id: sda4-root
+      - id: sda4-home
         device: sda
         type: partition
         number: 4
+        size: 2GB
+      - id: sda5-tmp
+        device: sda
+        type: partition
+        number: 5
+        size: 8GB
+      - id: sda6-var
+        device: sda
+        type: partition
+        number: 6
+        size: 40GB
+      - id: sda7-vartmp
+        device: sda
+        type: partition
+        number: 7
+        size: 8GB
+      - id: sda8-varlog
+        device: sda
+        type: partition
+        number: 8
+        size: 10GB
+      - id: sda9-varlogaudit
+        device: sda
+        type: partition
+        number: 9
+        size: 8GB
+      - id: sda10-root
+        device: sda
+        type: partition
+        number: 10
         size: -1
 
       - id: sda2-boot-ext4
@@ -81,15 +111,36 @@ autoinstall:
         type: format
         volume: sda3-swap
         fstype: swap
-      - id: sda4-root-btrfs
+      - id: sda4-home-ext4
         type: format
-        volume: sda4-root
+        volume: sda4-home
+        fstype: ext4
+      - id: sda5-tmp-ext4
+        type: format
+        volume: sda5-tmp
+        fstype: ext4
+      - id: sda6-var-btrfs
+        type: format
+        volume: sda6-var
         fstype: btrfs
+      - id: sda7-vartmp-ext4
+        type: format
+        volume: sda7-vartmp
+        fstype: ext4
+      - id: sda8-varlog-ext4
+        type: format
+        volume: sda8-varlog
+        fstype: ext4
+      - id: sda9-varlogaudit-ext4
+        type: format
+        volume: sda9-varlogaudit
+        fstype: ext4
+      - id: sda10-root-ext4
+        type: format
+        volume: sda10-root
+        fstype: ext4
 
-      - id: mount-sda4-root
-        type: mount
-        path: /
-        device: sda4-root-btrfs
+
       - id: mount-sda2-boot
         type: mount
         path: /boot
@@ -98,3 +149,31 @@ autoinstall:
         type: mount
         path: /swap.img
         device: sda3-swap-swap
+      - id: mount-sda4-home
+        type: mount
+        path: /home
+        device: sda4-home-ext4
+      - id: mount-sda5-tmp
+        type: mount
+        path: /tmp
+        device: sda5-tmp-ext4
+      - id: mount-sda6-var
+        type: mount
+        path: /var
+        device: sda6-var-btrfs
+      - id: mount-sda7-vartmp
+        type: mount
+        path: /var/tmp
+        device: sda7-vartmp-ext4
+      - id: mount-sda8-varlog
+        type: mount
+        path: /var/log
+        device: sda8-varlog-ext4
+      - id: mount-sda9-varlogaudit
+        type: mount
+        path: /var/log/audit
+        device: sda9-varlogaudit-ext4
+      - id: mount-sda10-root
+        type: mount
+        path: /
+        device: sda10-root-ext4

--- a/images/http/prod/user-data
+++ b/images/http/prod/user-data
@@ -77,27 +77,27 @@ autoinstall:
         type: partition
         number: 5
         size: 8GB
-      - id: sda6-var
+      - id: sda6-vartmp
         device: sda
         type: partition
         number: 6
-        size: 40GB
-      - id: sda7-vartmp
+        size: 8GB
+      - id: sda7-varlog
         device: sda
         type: partition
         number: 7
-        size: 8GB
-      - id: sda8-varlog
+        size: 10GB
+      - id: sda8-varlogaudit
         device: sda
         type: partition
         number: 8
-        size: 10GB
-      - id: sda9-varlogaudit
+        size: 8GB
+      - id: sda9-root
         device: sda
         type: partition
         number: 9
-        size: 8GB
-      - id: sda10-root
+        size: 10GB
+      - id: sda10-var
         device: sda
         type: partition
         number: 10
@@ -119,26 +119,26 @@ autoinstall:
         type: format
         volume: sda5-tmp
         fstype: ext4
-      - id: sda6-var-btrfs
+      - id: sda6-vartmp-ext4
         type: format
-        volume: sda6-var
+        volume: sda6-vartmp
+        fstype: ext4
+      - id: sda7-varlog-ext4
+        type: format
+        volume: sda7-varlog
+        fstype: ext4
+      - id: sda8-varlogaudit-ext4
+        type: format
+        volume: sda8-varlogaudit
+        fstype: ext4
+      - id: sda9-root-ext4
+        type: format
+        volume: sda9-root
+        fstype: ext4
+      - id: sda10-var-btrfs
+        type: format
+        volume: sda10-var
         fstype: btrfs
-      - id: sda7-vartmp-ext4
-        type: format
-        volume: sda7-vartmp
-        fstype: ext4
-      - id: sda8-varlog-ext4
-        type: format
-        volume: sda8-varlog
-        fstype: ext4
-      - id: sda9-varlogaudit-ext4
-        type: format
-        volume: sda9-varlogaudit
-        fstype: ext4
-      - id: sda10-root-ext4
-        type: format
-        volume: sda10-root
-        fstype: ext4
 
 
       - id: mount-sda2-boot
@@ -157,23 +157,23 @@ autoinstall:
         type: mount
         path: /tmp
         device: sda5-tmp-ext4
-      - id: mount-sda6-var
-        type: mount
-        path: /var
-        device: sda6-var-btrfs
-      - id: mount-sda7-vartmp
+      - id: mount-sda6-vartmp
         type: mount
         path: /var/tmp
-        device: sda7-vartmp-ext4
-      - id: mount-sda8-varlog
+        device: sda6-vartmp-ext4
+      - id: mount-sda7-varlog
         type: mount
         path: /var/log
-        device: sda8-varlog-ext4
-      - id: mount-sda9-varlogaudit
+        device: sda7-varlog-ext4
+      - id: mount-sda8-varlogaudit
         type: mount
         path: /var/log/audit
-        device: sda9-varlogaudit-ext4
-      - id: mount-sda10-root
+        device: sda8-varlogaudit-ext4
+      - id: mount-sda9-root
         type: mount
         path: /
-        device: sda10-root-ext4
+        device: sda9-root-ext4
+      - id: mount-sda10-var
+        type: mount
+        path: /var
+        device: sda10-var-btrfs

--- a/images/scripts/commons/docker.sh
+++ b/images/scripts/commons/docker.sh
@@ -6,7 +6,7 @@ set -o pipefail
 # Install docker
 # See https://docs.docker.com/install/linux/docker-ce/ubuntu/
 
-DOCKER_VERSION=5:20.10.6~3-0~ubuntu-focal
+DOCKER_VERSION=5:20.10.8~3-0~ubuntu-focal
 
 export DEBIAN_FRONTEND=noninteractive
 

--- a/images/template.dev.json
+++ b/images/template.dev.json
@@ -5,6 +5,7 @@
     "password": "vagrant",
     "memory": "8192",
     "cpus": "4",
+    "disk_size": "100000",
     "iso_url": "https://releases.ubuntu.com/20.04.2/ubuntu-20.04.2-live-server-amd64.iso",
     "iso_checksum": "sha256:d1f2bf834bbe9bb43faf16f9be992a6f3935e65be0edece1dee2aa6eb1767423"
   },
@@ -30,6 +31,7 @@
       ],
       "shutdown_command": "echo {{user `username`}} | sudo -S -E shutdown -P now",
       "hard_drive_interface": "sata",
+      "disk_size": "{{user `disk_size`}}",
       "vboxmanage": [
         [
           "modifyvm",

--- a/images/template.prod.json
+++ b/images/template.prod.json
@@ -72,6 +72,7 @@
 			"http_directory": "http/prod",
 			"headless": false,
 			"tools_upload_flavor": "linux",
+			"disk_size": "{{user `disk_size`}}",
 			"boot_wait": "5s",
 			"boot_command": [
 				"<enter><enter><f6><esc><wait> ",

--- a/images/template.prod.json
+++ b/images/template.prod.json
@@ -5,6 +5,7 @@
 		"password": "ces-admin",
 		"memory": "8192",
 		"cpus": "4",
+		"disk_size": "100000",
 		"iso_url": "https://releases.ubuntu.com/20.04.2/ubuntu-20.04.2-live-server-amd64.iso",
 		"iso_checksum": "sha256:d1f2bf834bbe9bb43faf16f9be992a6f3935e65be0edece1dee2aa6eb1767423"
 	},
@@ -31,6 +32,7 @@
 			],
 			"shutdown_command": "echo {{user `username`}} | sudo -S -E shutdown -P now",
 			"hard_drive_interface": "sata",
+			"disk_size": "{{user `disk_size`}}",
 			"vboxmanage": [
 				[
 					"modifyvm",

--- a/images/template.prod.json
+++ b/images/template.prod.json
@@ -94,6 +94,7 @@
 			"ssh_timeout": "15m",
 			"http_directory": "http/prod/QEMU",
 			"headless": false,
+			"disk_size": "{{user `disk_size`}}",
 			"boot_wait": "1s",
 			"boot_command": [
 				"<enter><enter><f6><esc><wait> ",


### PR DESCRIPTION
Resolves #435 
- Create additional partitions for
  - /home
  - /tmp
  - /var
  - /var/log
  - /var/tmp
  - /var/log/audit
- To make room for these partitions, the disk size is increased to 100 GB
- Upgrade Docker to 20.10.8
- Create additional config file which leaves out `/var/log` and `/var/log/audit` partitions