### PR TITLE
Delete update configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,17 @@
 # CES Changelog
 All notable changes to this project will be documented in this file.
 
+⚠️We only track changes that are directly related to the CES image build. 
+Other dependencies like apt packages and dogus, that may influence the instance behaviour, change between versions
+without specification in the changelog. ⚠️  
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- removed update configuration in `images/common/script/update.sh`. This behaviour is now handled by the ces-setup #445
+
+## [v20.04.3-1] - 2021-12-09
+### Removed
+- submodules #443

--- a/images/scripts/commons/update.sh
+++ b/images/scripts/commons/update.sh
@@ -3,26 +3,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Disable release-upgrades
-sed -i.bak 's/^Prompt=.*$/Prompt=never/' /etc/update-manager/release-upgrades
-
-# disable periodic updates
-cat <<EOF > /etc/apt/apt.conf.d/99_disable_periodic_update
-APT::Periodic::Enable "0";
-APT::Periodic::Update-Package-Lists "0";
-APT::Periodic::Unattended-Upgrade "0";
-EOF
-
-# stop and kill apt-daily
-systemctl stop apt-daily.timer
-systemctl disable apt-daily.timer
-systemctl stop apt-daily.service
-systemctl daemon-reload
-while fuser /var/lib/dpkg/lock >/dev/null 2>&1 ; do
-    sleep 1;
-done
-
-
 # dist upgrade
 export DEBIAN_FRONTEND=noninteractive
 apt-get -y update


### PR DESCRIPTION
The update configuration is no longer needed. It is handled by unattended-upgrades from the ces-setup.

see https://github.com/cloudogu/ces-setup/issues/150