### PR TITLE
Make update script more robust for packer build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Relicense to AGPL-3.0-only
+- Make update script more robust for packer build
 
 ## [v24.04.0-1] - 2024-07-23
 ### Changed

--- a/images/scripts/commons/update.sh
+++ b/images/scripts/commons/update.sh
@@ -29,3 +29,4 @@ apt-get -y update
 apt-get -y upgrade -o Dpkg::Options::="--force-confnew"
 
 reboot
+sleep 120

--- a/images/scripts/commons/update.sh
+++ b/images/scripts/commons/update.sh
@@ -29,4 +29,6 @@ apt-get -y update
 apt-get -y upgrade -o Dpkg::Options::="--force-confnew"
 
 reboot
-sleep 120
+while true; do
+  sleep 1
+done


### PR DESCRIPTION
After upgrading to Ubuntu 24.04 the reboot command at the end of the update.sh script does not immediately reboot the machine, which sometimes makes Packer run the next scripts without waiting for the reboot. To prevent this a sleep is added after the reboot command.